### PR TITLE
Add RELEASE_NAME variable to publish workflows

### DIFF
--- a/.github/workflows/publish-amo.yml
+++ b/.github/workflows/publish-amo.yml
@@ -29,6 +29,7 @@ jobs:
       id: release-meta
       run: |
         source release-info/release-metadata.env
+        RELEASE_NAME="${EXT_VERSION} (${RELEASE_TAG})"
         echo "EXT_NAME=${EXT_NAME}" >> $GITHUB_ENV
         echo "EXT_VERSION=${EXT_VERSION}" >> $GITHUB_ENV
         echo "RELEASE_TAG=${RELEASE_TAG}" >> $GITHUB_ENV

--- a/.github/workflows/publish-cws.yml
+++ b/.github/workflows/publish-cws.yml
@@ -29,6 +29,7 @@ jobs:
       id: release-meta
       run: |
         source release-info/release-metadata.env
+        RELEASE_NAME="${EXT_VERSION} (${RELEASE_TAG})"
         echo "EXT_NAME=${EXT_NAME}" >> $GITHUB_ENV
         echo "EXT_VERSION=${EXT_VERSION}" >> $GITHUB_ENV
         echo "RELEASE_TAG=${RELEASE_TAG}" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,6 @@ jobs:
           printf "EXT_VERSION=%q\n" "$EXT_VERSION"
           printf "EXT_ID=%q\n" "$EXT_ID"
           printf "RELEASE_TAG=%q\n" "$RELEASE_TAG"
-          printf "RELEASE_NAME=%q\n" "$RELEASE_NAME"
         } >> release-metadata.env
 
     - name: Upload release metadata


### PR DESCRIPTION
Introduces the RELEASE_NAME variable in the publish-amo and publish-cws workflows for consistency. Removes redundant RELEASE_NAME export from release.yml to avoid duplication.