### PR TITLE
Update privacy policy for OpenTubeX, shortcut, and instance check

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -11,13 +11,13 @@ RedirectTube is designed to work locally in your browser and does not collect pe
 
 ### Information the extension processes
 
-RedirectTube processes the current page URL and, when necessary, the source of YouTube links or embedded YouTube iframes in order to decide whether a link should be redirected to FreeTube or replaced with an in-browser placeholder.
+RedirectTube processes the current page URL and, when necessary, the source of YouTube links or embedded YouTube iframes in order to decide whether a link should be redirected to your selected player (FreeTube, OpenTubeX, Invidious, or Piped) or replaced with an in-browser placeholder.
 
 This processing happens in your browser and is used only to provide the extension's functionality.
 
 ### Data stored locally
 
-The extension saves configuration data in the browser's local extension storage and, for one toolbar label preference, in local storage. This includes settings such as:
+The extension saves configuration data in the browser's local extension storage. This includes settings such as:
 
 - popup behavior
 - auto-redirect behavior
@@ -25,19 +25,21 @@ The extension saves configuration data in the browser's local extension storage 
 - enhanced iframe preview preference
 - extension icon preference
 - custom URL rule configuration
-- translated language preference
-- custom toolbar button label
+- selected player (FreeTube, OpenTubeX, Invidious, or Piped) and preferred Invidious/Piped instance
+- keyboard shortcut enabled state and behavior (replace tab or open new tab)
+- onboarding completion status
 
 These settings remain on your device until you change or remove them.
 
 ### Network requests
 
-RedirectTube does not send your browsing history or personal data to the developer. However, some features may make direct requests from your browser to third-party services so the extension can display previews:
+RedirectTube does not send your browsing history or personal data to the developer. However, some features may make direct requests from your browser to third-party services:
 
 - If enhanced iframe preview is enabled, the extension may request YouTube thumbnail images from `i.ytimg.com`.
 - If enhanced iframe preview is enabled and the video title is not already provided, the extension may request video metadata from YouTube's oEmbed endpoint.
+- When you enter a custom Invidious or Piped instance during setup and use the "Check instance" button, the extension sends a direct request from your browser to that instance to confirm it is reachable.
 
-These requests are made only to provide the optional preview feature and are initiated by your browser when that feature is enabled.
+These requests are made only to provide the relevant feature and are initiated directly by your browser, not routed through the developer.
 
 ### External links
 
@@ -45,7 +47,7 @@ The options page and popup include links to external pages such as browser add-o
 
 ### Permissions
 
-RedirectTube requests browser permissions such as storage, tabs, and context menus only to provide its redirect and settings features. These permissions are not used to collect or transmit personal data to the developer.
+RedirectTube requests browser permissions such as storage, tabs, and context menus only to provide its redirect and settings features. The extension also runs on all sites so it can detect embedded YouTube videos on third-party pages. These permissions are not used to collect or transmit personal data to the developer.
 
 ### Your choices
 


### PR DESCRIPTION
Reflect current player options and stored settings, drop the removed toolbar-label localStorage and language-preference mentions, and disclose the instance-check network request and all_urls host access.